### PR TITLE
Subscriber queue

### DIFF
--- a/broker/internal/broker.go
+++ b/broker/internal/broker.go
@@ -1,25 +1,30 @@
 package internal
 
 type Broker struct {
-	Queues []Queue
+	MessageQueues   []Queue[Message]
+	SubscriberQueue Queue[Subscriber]
 }
 
 // Public:
 func NewBroker() *Broker {
 	broker := &Broker{}
-	broker.appendQueue(NewSliceQueue())
+	broker.appendMessageQueue(NewSliceQueue[Message]())
 	return broker
 }
 
 func (b *Broker) SendMessage(message *Message) error {
-	return b.Queues[0].enqueue(message)
+	return b.MessageQueues[0].enqueue(message)
 }
 
 func (b *Broker) ReceiveMessage() (*Message, error) {
-	return b.Queues[0].dequeue()
+	return b.MessageQueues[0].dequeue()
+}
+
+func (b *Broker) RegisterSubscriber(subscriber *Subscriber) error {
+	return b.SubscriberQueue.enqueue(subscriber)
 }
 
 // Private:
-func (b *Broker) appendQueue(q Queue) {
-	b.Queues = append(b.Queues, q)
+func (b *Broker) appendMessageQueue(q Queue[Message]) {
+	b.MessageQueues = append(b.MessageQueues, q)
 }

--- a/broker/internal/broker_test.go
+++ b/broker/internal/broker_test.go
@@ -1,9 +1,8 @@
 package internal
 
 import (
-	"testing"
-
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestCreateBroker_ShouldCreateBroker(t *testing.T) {
@@ -12,18 +11,18 @@ func TestCreateBroker_ShouldCreateBroker(t *testing.T) {
 	broker := NewBroker()
 
 	if assert.NotNil(broker) {
-		assert.Equal(1, len(broker.Queues))
+		assert.Equal(1, len(broker.MessageQueues))
 	}
 }
 
 func TestAppendQueueToBroker_ShouldAppendQueue(t *testing.T) {
 	assert := assert.New(t)
 
-	queue := NewSliceQueue()
+	queue := NewSliceQueue[Message]()
 	broker := NewBroker()
 
-	broker.appendQueue(queue)
-	len := len(broker.Queues)
+	broker.appendMessageQueue(queue)
+	len := len(broker.MessageQueues)
 
 	assert.Equal(2, len, "Broker should have two queues")
 }
@@ -37,16 +36,16 @@ func TestSendMessageToBroker_ShouldSendMessage(t *testing.T) {
 	err := broker.SendMessage(message)
 
 	assert.Nil(err)
-	assert.Equal(1, broker.Queues[0].len())
+	assert.Equal(1, broker.MessageQueues[0].len())
 
 	message = NewMessage(2, "Second message")
 	err = broker.SendMessage(message)
 	assert.Nil(err)
 
-	assert.Equal(2, broker.Queues[0].len())
+	assert.Equal(2, broker.MessageQueues[0].len())
 
-	firstMsg, _ := broker.Queues[0].dequeue()
-	secondMsg, _ := broker.Queues[0].dequeue()
+	firstMsg, _ := broker.MessageQueues[0].dequeue()
+	secondMsg, _ := broker.MessageQueues[0].dequeue()
 
 	assert.Equal(1, firstMsg.ID)
 	assert.Equal("First message", firstMsg.Content)
@@ -61,13 +60,13 @@ func TestReceiveMessageToBroker_ShouldReceiveMessage(t *testing.T) {
 	broker := NewBroker()
 	message := NewMessage(1, "First message")
 
-	err := broker.Queues[0].enqueue(message)
+	err := broker.MessageQueues[0].enqueue(message)
 
 	assert.Nil(err)
-	assert.Equal(1, broker.Queues[0].len())
+	assert.Equal(1, broker.MessageQueues[0].len())
 
 	message = NewMessage(2, "Second message")
-	err = broker.Queues[0].enqueue(message)
+	err = broker.MessageQueues[0].enqueue(message)
 	assert.Nil(err)
 
 	firstMsg, _ := broker.ReceiveMessage()

--- a/broker/internal/queue.go
+++ b/broker/internal/queue.go
@@ -7,35 +7,35 @@ var (
 	ErrQueueFull  = errors.New("queue full")
 )
 
-type Queue interface {
-	enqueue(*Message) error
-	dequeue() (*Message, error)
+type Queue[T any] interface {
+	enqueue(*T) error
+	dequeue() (*T, error)
 	len() int
 }
 
-type SliceQueue []*Message
+type SliceQueue[T any] []*T
 
-func NewSliceQueue() Queue {
-	return &SliceQueue{}
+func NewSliceQueue[T any]() Queue[T] {
+	return &SliceQueue[T]{}
 }
 
-func (q *SliceQueue) len() int {
+func (q *SliceQueue[T]) len() int {
 	return len(*q)
 }
 
-func (q *SliceQueue) enqueue(value *Message) error {
+func (q *SliceQueue[T]) enqueue(value *T) error {
 	*q = append(*q, value)
 	return nil
 }
 
-func (q *SliceQueue) dequeue() (*Message, error) {
+func (q *SliceQueue[T]) dequeue() (*T, error) {
 	queue := *q
 	if len(*q) > 0 {
-		card := queue[0]
+		element := queue[0]
 		*q = queue[1:]
-		return card, nil
+		return element, nil
 	}
 
-	var empty Message
+	var empty T
 	return &empty, ErrQueueEmpty
 }

--- a/broker/internal/queue_test.go
+++ b/broker/internal/queue_test.go
@@ -1,15 +1,14 @@
 package internal
 
 import (
-	"testing"
-
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestCreateQueue_ShouldCreateQueue(t *testing.T) {
 	assert := assert.New(t)
 
-	queue := NewSliceQueue()
+	queue := NewSliceQueue[Message]()
 
 	assert.NotNil(queue)
 }
@@ -17,7 +16,7 @@ func TestCreateQueue_ShouldCreateQueue(t *testing.T) {
 func TestEnqueue_ShouldEnqueueMessage(t *testing.T) {
 	assert := assert.New(t)
 
-	queue := &SliceQueue{}
+	queue := &SliceQueue[Message]{}
 	queue.enqueue(NewMessage(1, "First message"))
 
 	assert.Equal(1, (*queue)[0].ID)
@@ -34,7 +33,7 @@ func TestEnqueue_ShouldEnqueueMessage(t *testing.T) {
 func TestDequeue_ShouldDequeueMessage(t *testing.T) {
 	assert := assert.New(t)
 
-	queue := &SliceQueue{}
+	queue := &SliceQueue[Message]{}
 
 	queue.enqueue(NewMessage(1, "Hello Go"))
 	dequeuedMessage, err := queue.dequeue()
@@ -50,7 +49,7 @@ func TestGetQueueLength_ShouldReturnLength(t *testing.T) {
 	assert := assert.New(t)
 
 	//queue -> []*Message
-	queue := &SliceQueue{}
+	queue := &SliceQueue[Message]{}
 
 	assert.Equal(0, queue.len())
 
@@ -67,7 +66,7 @@ func TestGetQueueLength_ShouldReturnLength(t *testing.T) {
 
 func TestGetQueueLength_ShouldReturnLength2(t *testing.T) {
 	type args struct {
-		queue       *SliceQueue
+		queue       *SliceQueue[Message]
 		enqueueMsgs []Message
 		dequeueMsgs int
 	}
@@ -77,11 +76,11 @@ func TestGetQueueLength_ShouldReturnLength2(t *testing.T) {
 		arguments args
 		want      int
 	}{
-		{"Test len 0", args{queue: &SliceQueue{}, enqueueMsgs: []Message{}, dequeueMsgs: 0}, 0},
-		{"Test len 0 - Only Dequeue", args{queue: &SliceQueue{}, enqueueMsgs: []Message{}, dequeueMsgs: 1}, 0},
+		{"Test len 0", args{queue: &SliceQueue[Message]{}, enqueueMsgs: []Message{}, dequeueMsgs: 0}, 0},
+		{"Test len 0 - Only Dequeue", args{queue: &SliceQueue[Message]{}, enqueueMsgs: []Message{}, dequeueMsgs: 1}, 0},
 		{"Test len 3 - Only Enqueue",
 			args{
-				queue: &SliceQueue{},
+				queue: &SliceQueue[Message]{},
 				enqueueMsgs: []Message{
 					{ID: 1, Content: "Mesg 1"},
 					{ID: 2, Content: "Mesg 2"},
@@ -89,7 +88,7 @@ func TestGetQueueLength_ShouldReturnLength2(t *testing.T) {
 				},
 				dequeueMsgs: 0,
 			}, 3},
-		{"Te len 2 - Enqueue and Dequeue", args{queue: &SliceQueue{},
+		{"Te len 2 - Enqueue and Dequeue", args{queue: &SliceQueue[Message]{},
 			enqueueMsgs: []Message{
 				{ID: 1, Content: "Mesg 1"},
 				{ID: 2, Content: "Mesg 2"},

--- a/broker/internal/subscriber.go
+++ b/broker/internal/subscriber.go
@@ -1,0 +1,15 @@
+package internal
+
+type Subscriber struct {
+	ID          int
+	EventType   string
+	ConsumerUrl string
+}
+
+func NewSubscriber(id int, eventType string, url string) *Subscriber {
+	return &Subscriber{
+		ID:          id,
+		EventType:   eventType,
+		ConsumerUrl: url,
+	}
+}


### PR DESCRIPTION
- Creates the `Subscriber` struct
- Makes the queue generic to receive `Message` or `Subcriber`
- Add `Subscriber` queue to the broker